### PR TITLE
forwards owner object into flow asset instance

### DIFF
--- a/Plugins/Flow/Source/Flow/Private/FlowAsset.cpp
+++ b/Plugins/Flow/Source/Flow/Private/FlowAsset.cpp
@@ -222,8 +222,9 @@ void UFlowAsset::SetInspectedInstance(const FName& NewInspectedInstanceName)
 }
 #endif
 
-void UFlowAsset::InitInstance(UFlowAsset* InTemplateAsset)
+void UFlowAsset::InitInstance(UObject* InOwner, UFlowAsset* InTemplateAsset)
 {
+	Owner = InOwner;
 	TemplateAsset = InTemplateAsset;
 
 	for (TPair<FGuid, UFlowNode*>& Node : Nodes)
@@ -341,6 +342,11 @@ void UFlowAsset::FinishFlow(const bool bFlowCompleted)
 
 		NodeOwningThisAssetInstance = nullptr;
 	}
+}
+
+UObject* UFlowAsset::GetOwner() const
+{
+	return Owner;
 }
 
 TWeakObjectPtr<UFlowAsset> UFlowAsset::GetFlowInstance(UFlowNode_SubGraph* SubGraphNode) const

--- a/Plugins/Flow/Source/Flow/Private/FlowSubsystem.cpp
+++ b/Plugins/Flow/Source/Flow/Private/FlowSubsystem.cpp
@@ -44,7 +44,7 @@ void UFlowSubsystem::StartRootFlow(UObject* Owner, UFlowAsset* FlowAsset)
 		return;
 	}
 
-	UFlowAsset* NewFlow = CreateFlowInstance(FlowAsset);
+	UFlowAsset* NewFlow = CreateFlowInstance(Owner, FlowAsset);
 	RootInstances.Add(Owner, NewFlow);
 
 	NewFlow->StartFlow();
@@ -63,7 +63,8 @@ void UFlowSubsystem::PreloadSubFlow(UFlowNode_SubGraph* SubFlow)
 {
 	if (!InstancedSubFlows.Contains(SubFlow))
 	{
-		UFlowAsset* NewFlow = CreateFlowInstance(SubFlow->Asset);
+		UObject* Owner = SubFlow->Asset.IsNull() ? nullptr : SubFlow->Asset->GetOwner();
+		UFlowAsset* NewFlow = CreateFlowInstance(Owner, SubFlow->Asset);
 		InstancedSubFlows.Add(SubFlow, NewFlow);
 
 		NewFlow->PreloadNodes();
@@ -74,7 +75,8 @@ void UFlowSubsystem::StartSubFlow(UFlowNode_SubGraph* SubFlow)
 {
 	if (!InstancedSubFlows.Contains(SubFlow))
 	{
-		UFlowAsset* NewFlow = CreateFlowInstance(SubFlow->Asset);
+		UObject* Owner = SubFlow->Asset.IsNull() ? nullptr : SubFlow->Asset->GetOwner();
+		UFlowAsset* NewFlow = CreateFlowInstance(Owner, SubFlow->Asset);
 		InstancedSubFlows.Add(SubFlow, NewFlow);
 	}
 
@@ -96,7 +98,7 @@ void UFlowSubsystem::RemoveInstancedTemplate(UFlowAsset* Template)
 	InstancedTemplates.Remove(Template);
 }
 
-UFlowAsset* UFlowSubsystem::CreateFlowInstance(TSoftObjectPtr<UFlowAsset> FlowAsset)
+UFlowAsset* UFlowSubsystem::CreateFlowInstance(UObject* Owner, TSoftObjectPtr<UFlowAsset> FlowAsset)
 {
 	check(!FlowAsset.IsNull());
 
@@ -118,7 +120,7 @@ UFlowAsset* UFlowSubsystem::CreateFlowInstance(TSoftObjectPtr<UFlowAsset> FlowAs
 
 	const FString NewInstanceName = FPaths::GetBaseFilename(FlowAsset.Get()->GetPathName()) + TEXT("_") + FString::FromInt(FlowAsset.Get()->GetInstancesNum());
 	UFlowAsset* NewInstance = NewObject<UFlowAsset>(this, FlowAsset->GetClass(), *NewInstanceName, RF_Transient, FlowAsset.Get(), false, nullptr);
-	NewInstance->InitInstance(FlowAsset.Get());
+	NewInstance->InitInstance(Owner, FlowAsset.Get());
 
 	FlowAsset.Get()->AddInstance(NewInstance);
 

--- a/Plugins/Flow/Source/Flow/Public/FlowAsset.h
+++ b/Plugins/Flow/Source/Flow/Public/FlowAsset.h
@@ -162,6 +162,9 @@ private:
 	TMap<TWeakObjectPtr<UFlowNode_SubGraph>, TWeakObjectPtr<UFlowAsset>> ActiveSubGraphs;
 
 	UPROPERTY()
+	UObject* Owner;
+
+	UPROPERTY()
 	UFlowNode_Start* StartNode;
 
 	UPROPERTY()
@@ -179,13 +182,14 @@ private:
 	TArray<UFlowNode*> RecordedNodes;
 
 public:
-	void InitInstance(UFlowAsset* InTemplateAsset);
+	void InitInstance(UObject* InOwner, UFlowAsset* InTemplateAsset);
 	void PreloadNodes();
 
 	virtual void StartFlow();
 	virtual void StartAsSubFlow(UFlowNode_SubGraph* SubGraphNode);
 	virtual void FinishFlow(const bool bFlowCompleted);
 
+	UObject* GetOwner() const;
 	TWeakObjectPtr<UFlowAsset> GetFlowInstance(UFlowNode_SubGraph* SubGraphNode) const;
 
 private:

--- a/Plugins/Flow/Source/Flow/Public/FlowSubsystem.h
+++ b/Plugins/Flow/Source/Flow/Public/FlowSubsystem.h
@@ -59,7 +59,7 @@ public:
 	void RemoveInstancedTemplate(UFlowAsset* Template);
 
 private:
-	UFlowAsset* CreateFlowInstance(TSoftObjectPtr<UFlowAsset> FlowAsset);
+	UFlowAsset* CreateFlowInstance(UObject* Owner, TSoftObjectPtr<UFlowAsset> FlowAsset);
 
 public:
 	// Returns assets instanced by object from another system like World Settings


### PR DESCRIPTION
Maybe I've just missed it, but I don't see any way to retrieve the owner of a graph flow at runtime. The outer of the template `UFlowAsset` is its package, the outer of the `UFlowAsset` instance is the subsystem and I couldn't find anyway to retrieve the actual owner of the asset (e.g. the object that starts the root flow, `AFlowWorldSettings` in your examples, we have a flow on the player controller and we need to access the controller that is being "flowed")