### PR TITLE
removes constraint on subsystem that it's created only on authority and push the constraint back to world settings

### DIFF
--- a/Plugins/Flow/Source/Flow/Private/FlowSubsystem.cpp
+++ b/Plugins/Flow/Source/Flow/Private/FlowSubsystem.cpp
@@ -13,11 +13,6 @@ UFlowSubsystem::UFlowSubsystem()
 {
 }
 
-bool UFlowSubsystem::ShouldCreateSubsystem(UObject* Outer) const
-{
-	return Outer->GetWorld()->GetNetMode() < NM_Client && Outer->GetWorld()->IsServer();
-}
-
 void UFlowSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
 }

--- a/Plugins/Flow/Source/Flow/Private/FlowWorldSettings.cpp
+++ b/Plugins/Flow/Source/Flow/Private/FlowWorldSettings.cpp
@@ -11,7 +11,7 @@ void AFlowWorldSettings::BeginPlay()
 {
 	Super::BeginPlay();
 
-	if (FlowAsset)
+	if (FlowAsset && HasAuthority())
 	{
 		if (UFlowSubsystem* FlowSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UFlowSubsystem>())
 		{
@@ -22,7 +22,7 @@ void AFlowWorldSettings::BeginPlay()
 
 void AFlowWorldSettings::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
-	if (FlowAsset)
+	if (FlowAsset && HasAuthority())
 	{
 		if (UFlowSubsystem* FlowSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UFlowSubsystem>())
 		{

--- a/Plugins/Flow/Source/Flow/Public/FlowSubsystem.h
+++ b/Plugins/Flow/Source/Flow/Public/FlowSubsystem.h
@@ -41,8 +41,6 @@ class FLOW_API UFlowSubsystem : public UGameInstanceSubsystem
 	TMap<UFlowNode_SubGraph*, UFlowAsset*> InstancedSubFlows;
 
 public:
-	virtual bool ShouldCreateSubsystem(UObject* Outer) const override;
-
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
 	virtual void Deinitialize() override;
 


### PR DESCRIPTION
This one is debatable honestly, but if the project goes into this direction, we'll have to fork and we will not be able to contribute to the project anymore.

We're using client side flows. In fact, we're using lots of them. For instance, when we greet a player, the player will have a client side flow first, then when all players are ready, the server flow continues. 

I think the subsystem should be instantiated everywhere, and there should be no limitations as to where the flow is instantiated. For the global level flow, I've added `HasAuthority()` to prevent the flow from being instantiated on the client.