### PR TITLE
Compiler errors

### DIFF
--- a/Plugins/Flow/Source/FlowEditor/Private/Graph/FlowGraphConnectionDrawingPolicy.cpp
+++ b/Plugins/Flow/Source/FlowEditor/Private/Graph/FlowGraphConnectionDrawingPolicy.cpp
@@ -86,8 +86,8 @@ void FFlowGraphConnectionDrawingPolicy::BuildPaths()
 			{
 				for (UEdGraphPin* Pin : SelectedNode->Pins)
 				{
-					if (Pin->Direction == EGPD_Input && UFlowGraphSettings::Get()->bHighlightInputWiresOfSelectedNodes
-						|| Pin->Direction == EGPD_Output && UFlowGraphSettings::Get()->bHighlightOutputWiresOfSelectedNodes)
+					if ((Pin->Direction == EGPD_Input && UFlowGraphSettings::Get()->bHighlightInputWiresOfSelectedNodes)
+						|| (Pin->Direction == EGPD_Output && UFlowGraphSettings::Get()->bHighlightOutputWiresOfSelectedNodes))
 					{
 						for (UEdGraphPin* LinkedPin : Pin->LinkedTo)
 						{

--- a/Plugins/Flow/Source/FlowEditor/Private/Graph/FlowGraphSchema_Actions.cpp
+++ b/Plugins/Flow/Source/FlowEditor/Private/Graph/FlowGraphSchema_Actions.cpp
@@ -120,3 +120,5 @@ UEdGraphNode* FFlowGraphSchemaAction_NewComment::PerformAction(class UEdGraph* P
 
 	return FEdGraphSchemaAction_NewNode::SpawnNodeFromTemplate<UEdGraphNode_Comment>(ParentGraph, CommentTemplate, SpawnLocation);
 }
+
+#undef LOCTEXT_NAMESPACE


### PR DESCRIPTION
Fix compiler errors caused by [-Werror,-Wlogical-op-parentheses] and LOCTEXT_NAMESPACE' macro redefinition